### PR TITLE
fastapi에서 파일 버퍼를 디스크에 쓰지 않도록 제한해보았다.

### DIFF
--- a/prepline_general/api/general.py
+++ b/prepline_general/api/general.py
@@ -48,7 +48,7 @@ from unstructured.staging.base import (
 )
 from unstructured_inference.models.chipper import MODEL_TYPES as CHIPPER_MODEL_TYPES
 from unstructured_inference.models.base import UnknownModelException
-
+from tempfile import SpooledTemporaryFile
 
 app = FastAPI()
 router = APIRouter()
@@ -269,6 +269,13 @@ def pipeline_api(
     m_max_characters=[],
     m_extract_image_block_types=None,
 ):
+    logger.info(f"the instance of file is {type(file)}")
+    if isinstance(file, SpooledTemporaryFile) or not isinstance(file, io.BytesIO):
+        file_content = file.read()
+        file = io.BytesIO(file_content)
+        file.seek(0)  # 파일 포인터를 시작점으로 되돌립니다.
+    logger.info(f"After conversion, the instance of file is {type(file)}")
+
     if filename.endswith(".msg"):
         # Note(yuming): convert file type for msg files
         # since fast api might sent the wrong one.


### PR DESCRIPTION
현재 `/api/general.py` 에서 `pipeline_1` 메소드에 대하여

```
@router.post("/general/v0/general")
@router.post("/general/v0.0.50/general")
def pipeline_1(
    request: Request,
    gz_uncompressed_content_type: Optional[str] = Form(default=None),
    files: Union[List[UploadFile], None] = File(default=None),
    output_format: Union[str, None] = Form(default=None),
    coordinates: List[str] = Form(default=[]),
    encoding: List[str] = Form(default=[]),
    hi_res_model_name: List[str] = Form(default=[]),
    include_page_breaks: List[str] = Form(default=[]),
    ocr_languages: List[str] = Form(default=[]),
    pdf_infer_table_structure: List[str] = Form(default=[]),
    skip_infer_table_types: List[str] = Form(default=[]),
    strategy: List[str] = Form(default=[]),
    xml_keep_tags: List[str] = Form(default=[]),
    languages: List[str] = ["eng"],
    chunking_strategy: List[str] = Form(default=[]),
    multipage_sections: List[str] = Form(default=[]),
    combine_under_n_chars: List[str] = Form(default=[]),
    new_after_n_chars: List[str] = Form(default=[]),
):

```

여기서 files를 보면 fastapi에서 쓰고 있는 놈이고 form data할 때 쓰임

```
class UploadFile:
    """
    An uploaded file included as part of the request data.
    """

    def __init__(
        self,
        file: typing.BinaryIO,
        *,
        size: typing.Optional[int] = None,
        filename: typing.Optional[str] = None,
        headers: "typing.Optional[Headers]" = None,
    ) -> None:
        self.filename = filename
        self.file = file
        self.size = size
        self.headers = headers or Headers()

```

formparsers.py에 가면 SpooledTemporaryFile을 사용하고 있음. 근데 이거 1MB가 max_size로 보임.

```
#https://stackoverflow.com/questions/65342833/fastapi-uploadfile-is-slow-compared-to-flask

class MultiPartParser:
    max_file_size = 1024 * 1024

 if b"filename" in options:
            self._current_files += 1
            if self._current_files > self.max_files:
                raise MultiPartException(
                    f"Too many files. Maximum number of files is {self.max_files}."
                )
            filename = _user_safe_decode(options[b"filename"], self._charset)
            tempfile = SpooledTemporaryFile(max_size=self.max_file_size)
            self._files_to_close_on_error.append(tempfile)
            self._current_part.file = UploadFile(
                file=tempfile,  # type: ignore[arg-type]
                size=0,
                filename=filename,
                headers=Headers(raw=self._current_part.item_headers),
            )

```

```
tempfile = SpooledTemporaryFile(max_size=self.max_file_size)
```

여기에서의 max_size가 뭐냐면, max_size를 넘어가는 경우에는 spooledtemporaryfile에 대하여서는 실제 디스크로 I/O를 한다.

```
class SpooledTemporaryFile:
    """Temporary file wrapper, specialized to switch from BytesIO
    or StringIO to a real file when it exceeds a certain size or
    when a fileno is needed.
    """
    _rolled = False

    def __init__(self, max_size=0, mode='w+b', buffering=-1,
                 encoding=None, newline=None,
                 suffix=None, prefix=None, dir=None, *, errors=None):
        if 'b' in mode:
            self._file = _io.BytesIO()
        else:
            encoding = _io.text_encoding(encoding)
            self._file = _io.TextIOWrapper(_io.BytesIO(),
                            encoding=encoding, errors=errors,
                            newline=newline)
        self._max_size = max_size
        self._rolled = False
        self._TemporaryFileArgs = {'mode': mode, 'buffering': buffering,
                                   'suffix': suffix, 'prefix': prefix,
                                   'encoding': encoding, 'newline': newline,
                                   'dir': dir, 'errors': errors}

    __class_getitem__ = classmethod(_types.GenericAlias)

    def _check(self, file):
        if self._rolled: return
        max_size = self._max_size
        if max_size and file.tell() > max_size:
            self.rollover()

```

```
max_file_size = 1024 * 1024
```

[[FastAPI UploadFile is slow compared to Flask](https://stackoverflow.com/questions/65342833/fastapi-uploadfile-is-slow-compared-to-flask)](https://stackoverflow.com/questions/65342833/fastapi-uploadfile-is-slow-compared-to-flask)

위 문서를 참고함.

이 부분을 수정하면 인메모리로 계속 처리될 수 있을까? 

- 코드 수정 `prepline_general/api/general.py`
- 아래에 [[logger.info](http://logger.info/)](http://logger.info) spooled temporarily file 추가 수정하는 로직을 넣음

```jsx
def pipeline_api(
    file: IO[bytes],
    request: Request,
    # -- chunking options --
    chunking_strategy: Optional[str],
    combine_under_n_chars: Optional[int],
    max_characters: int,
    multipage_sections: bool,
    new_after_n_chars: Optional[int],
    overlap: int,
    overlap_all: bool,
    # ----------------------
    filename: str = "",
    file_content_type: Optional[str] = None,
    response_type: str = "application/json",
    coordinates: bool = False,
    encoding: str = "utf-8",
    hi_res_model_name: Optional[str] = None,
    include_page_breaks: bool = False,
    ocr_languages: Optional[List[str]] = None,
    pdf_infer_table_structure: bool = True,
    skip_infer_table_types: Optional[List[str]] = None,
    strategy: str = "auto",
    xml_keep_tags: bool = False,
    languages: Optional[List[str]] = None,
    extract_image_block_types: Optional[List[str]] = None,
    unique_element_ids: Optional[bool] = False,
) -> List[Dict[str, Any]] | str:
    logger.info(f"the instance of file is {type(file)}")
    if isinstance(file, SpooledTemporaryFile) or not isinstance(file, io.BytesIO):
        file_content = file.read()
        file = io.BytesIO(file_content)
        file.seek(0)  # 파일 포인터를 시작점으로 되돌립니다.
    logger.info(f"After conversion, the instance of file is {type(file)}")
    
```

### EKS에서 테스트해보자

- 하지만 24분 → 기존과 동일함. bad luck.

```
🐿H   ~/.ssh  kubectl logs unstructuredio-76f54dc569-wdbvw -n test -f
2024-07-04 09:10:20,584 unstructured_api INFO Started Unstructured API
2024-07-04 09:10:20,585 uvicorn.error INFO Started server process [7]
2024-07-04 09:10:20,585 uvicorn.error INFO Waiting for application startup.
2024-07-04 09:10:20,585 uvicorn.error INFO Application startup complete.
2024-07-04 09:10:20,586 uvicorn.error INFO Uvicorn running on http://0.0.0.0:8000 (Press CTRL+C to quit)
2024-07-04 09:11:10,144 unstructured_api INFO the instance of file is <class 'tempfile.SpooledTemporaryFile'>
2024-07-04 09:11:10,174 unstructured_api INFO After conversion, the instance of file is <class '_io.BytesIO'>
2024-07-04 09:11:10,349 unstructured_api DEBUG partition input data: {"content_type": "application/pdf", "strategy": "auto", "ocr_languages": null, "coordinates": false, "pdf_infer_table_structure": false, "include_page_breaks": false, "encoding": "utf-8", "hi_res_model_name": null, "xml_keep_tags": false, "skip_infer_table_types": [], "languages": null, "chunking_strategy": null, "multipage_sections": true, "combine_under_n_chars": null, "new_after_n_chars": null, "max_characters": 500, "overlap": 0, "overlap_all": false, "extract_image_block_types": null, "extract_image_block_to_payload": false, "unique_element_ids": false}
2024-07-04 09:11:10,349 unstructured WARNING The pdf_infer_table_structure kwarg is deprecated. Please use skip_infer_table_types instead.
2024-07-04 09:11:10,394 unstructured INFO calling with bytesio!!!!!!!!!!!!!!!!
Ignoring (part of) ToUnicode map because the PDF data does not conform to the format. This could result in (cid) values in the output. The start object is not a byte.
Ignoring (part of) ToUnicode map because the PDF data does not conform to the format. This could result in (cid) values in the output. The start object is not a byte.
Ignoring (part of) ToUnicode map because the PDF data does not conform to the format. This could result in (cid) values in the output. The start object is not a byte.
Ignoring (part of) ToUnicode map because the PDF data does not conform to the format. This could result in (cid) values in the output. The start object is not a byte.
Ignoring (part of) ToUnicode map because the PDF data does not conform to the format. This could result in (cid) values in the output. The start object is not a byte.
Ignoring (part of) ToUnicode map because the PDF data does not conform to the format. This could result in (cid) values in the output. The start object is not a byte.
Ignoring (part of) ToUnicode map because the PDF data does not conform to the format. This could result in (cid) values in the output. The start object is not a byte.
Ignoring (part of) ToUnicode map because the PDF data does not conform to the format. This could result in (cid) values in the output. The start object is not a byte.
Ignoring (part of) ToUnicode map because the PDF data does not conform to the format. This could result in (cid) values in the output. The start object is not a byte.
Ignoring (part of) ToUnicode map because the PDF data does not conform to the format. This could result in (cid) values in the output. The start object is not a byte.
Ignoring (part of) ToUnicode map because the PDF data does not conform to the format. This could result in (cid) values in the output. The start object is not a byte.
Ignoring (part of) ToUnicode map because the PDF data does not conform to the format. This could result in (cid) values in the output. The start object is not a byte.
Ignoring (part of) ToUnicode map because the PDF data does not conform to the format. This could result in (cid) values in the output. The start object is not a byte.
Ignoring (part of) ToUnicode map because the PDF data does not conform to the format. This could result in (cid) values in the output. The start object is not a byte.
Ignoring (part of) ToUnicode map because the PDF data does not conform to the format. This could result in (cid) values in the output. The start object is not a byte.
Ignoring (part of) ToUnicode map because the PDF data does not conform to the format. This could result in (cid) values in the output. The start object is not a byte.
Ignoring (part of) ToUnicode map because the PDF data does not conform to the format. This could result in (cid) values in the output. The start object is not a byte.
Ignoring (part of) ToUnicode map because the PDF data does not conform to the format. This could result in (cid) values in the output. The start object is not a byte.
Ignoring (part of) ToUnicode map because the PDF data does not conform to the format. This could result in (cid) values in the output. The start object is not a byte.
2024-07-04 09:35:35,013 10.0.2.36:56518 POST /general/v0/general HTTP/1.1 - 200 OK
```